### PR TITLE
Fix link previews

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Dylan Hand
 main-text: Dylan Hand
 subtitle:
 tagline: Official Site
-logo: &profile-pic '/assets/img/optimized/profile-pic.jpg'
+logo: &profile-pic '/assets/img/profile-pic.jpg'
 description: Official site of rapper Dylan Hand.
 # baseurl: "/yo" # the subpath of your site, e.g. /blog
 url: &url https://dylanhand.com

--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ google-analytics: G-KRGRNSZ5Y9 # add your identifier. For example UA-99631805-1.
 
 # jekyll-picture-tag plugin
 picture:
-  source: assets/img/
+  source: /
   # source: assets/img/_fullsize # using a folder starting with '_' will exclude it from being copied to the _site folder
 
 # Jekyll-seo-tag plugin

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,6 @@
 ---
 <!-- layout: compress -->
-image: '/assets/img/optimized/profile-pic.jpg'
+image: '/assets/img/profile-pic.jpg'
 ---
 
 <!DOCTYPE html>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -7,7 +7,7 @@ layout: default
   <section class="author" data-aos="fade-up" data-aos-easing="ease-out-quad" data-aos-duration="700">
     <div class="author__inner">
       <div class="author__img" alt="{{site.author.name}}">
-        {% picture profile profile-pic.jpg --alt Profile picture of Dylan Hand wearing
+        {% picture profile assets/img/profile-pic.jpg --alt Profile picture of Dylan Hand wearing
           green hoodie with yellow background %}
       </div>
       <div class="author__contact__profile">

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,7 +2,7 @@
 layout: page
 title: About
 permalink: /about/
-image: 'profile-pic-red.jpg'
+image: 'assets/img/profile-pic-red.jpg'
 image_alt: 'Dylan Hand in front of a bright red background wearing a blue jacket'
 ---
 

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,5 +1,5 @@
 ---
 layout: index
 permalink: /
-image: '/assets/img/optimized/profile-pic.jpg'
+image: '/assets/img/profile-pic.jpg'
 ---

--- a/_pages/music.md
+++ b/_pages/music.md
@@ -2,5 +2,5 @@
 layout: music
 title: Music
 permalink: /music/
-image: '/assets/img/optimized/profile-pic.jpg'
+image: '/assets/img/profile-pic.jpg'
 ---

--- a/_posts/2019-07-02-freestyling-with-a-random-word-generator.md
+++ b/_posts/2019-07-02-freestyling-with-a-random-word-generator.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title:  "Video: Freestyling with a random word generator"
-date:   2019-07-02
-image:  'word-generator-freestyle.jpg'
-image_alt:  'Picture of Dylan Hand holding phone with random word generator app'
-tags:   raps freestyle word-generator
+title: "Video: Freestyling with a random word generator"
+date: 2019-07-02
+image: 'assets/img/word-generator-freestyle.jpg'
+image_alt: 'Picture of Dylan Hand holding phone with random word generator app'
+tags: raps freestyle word-generator
 ---
 
 Freestyle practice using [RapScript](https://rapscript.net).

--- a/_posts/2019-07-09-scotland-song.md
+++ b/_posts/2019-07-09-scotland-song.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title:  "Video: I went to Scotland and made a song out of explosions, laughs, and screams"
-date:   2019-07-09
-image:  'scotland-rap.jpg'
-image_alt:  'Picture of Dylan Hand holding Teenage Engineering PO-33 sampler'
-tags:   raps po-33 goat
+title: "Video: I went to Scotland and made a song out of explosions, laughs, and screams"
+date: 2019-07-09
+image: 'assets/img/scotland-rap.jpg'
+image_alt: 'Picture of Dylan Hand holding Teenage Engineering PO-33 sampler'
+tags: raps po-33 goat
 ---
 
 On the flight back from visiting one old and several new friends in Scotland, I took some audio samples from a lo-fi video of fireworks being set off and made a beat. Then rapped. Then said fuck it and made a video.

--- a/_posts/2019-09-20-ukulele-freestyle.md
+++ b/_posts/2019-09-20-ukulele-freestyle.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title:  "Video: Ukulele Freestyle"
-date:   2019-09-20
-image:  'ukulele-freestyle.jpg'
+title: "Video: Ukulele Freestyle"
+date: 2019-09-20
+image: 'assets/img/ukulele-freestyle.jpg'
 image_alt: 'Picture of Dylan Hand standing at microphone wearing headphones'
-tags:   raps freestyle
+tags: raps freestyle
 ---
 
 A made up story over a ukulele beat.

--- a/_posts/2020-08-19-sole.md
+++ b/_posts/2020-08-19-sole.md
@@ -2,7 +2,7 @@
 layout: post
 title: 'New Song - "Sole"'
 date: 2020-08-19
-image: 'sole.jpg'
+image: 'assets/img/sole.jpg'
 tags: raps
 ---
 

--- a/_posts/2020-09-07-sole-video.md
+++ b/_posts/2020-09-07-sole-video.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title:  "Music Video - \"Sole\""
-date:   2020-09-07
-image:  'fuckin-muffin.jpg'
-image_alt:  'Close up picture of Dylan Hand eating messy jelly sandwich'
-tags:   raps
+title: "Music Video - \"Sole\""
+date: 2020-09-07
+image: 'assets/img/fuckin-muffin.jpg'
+image_alt: 'Close up picture of Dylan Hand eating messy jelly sandwich'
+tags: raps
 ---
 
 New video for "Sole," the song I did with [Rotaris](https://rotarismusic.com/). Dedicated to all you sickos out there.

--- a/_posts/2020-11-08-new-studio.md
+++ b/_posts/2020-11-08-new-studio.md
@@ -1,16 +1,16 @@
 ---
 layout: post
-title:  "New Studio"
-date:   2020-11-08
-image:  'studio/studio-close.jpg'
-image_alt:  'Picture of music studio with computer, speakers, and microphone'
-tags:   raps studio
+title: "New Studio"
+date: 2020-11-08
+image: 'assets/img/studio/studio-close.jpg'
+image_alt: 'Picture of music studio with computer, speakers, and microphone'
+tags: raps studio
 ---
 
 After many moons of wanting to, I finally did it. I’ve got a studio now.
 
 Actually been here a handful of weeks and have some new stuff cooking. Can’t wait to share more.
 
-{% picture post studio/studio-entrance.jpg %}
-{% picture post studio/studio-hall.jpg %}
-{% picture post studio/studio-lounge.jpg %}
+{% picture post assets/img/studio/studio-entrance.jpg %}
+{% picture post assets/img/studio/studio-hall.jpg %}
+{% picture post assets/img/studio/studio-lounge.jpg %}

--- a/_posts/2020-11-12-word-generator-freestyle.md
+++ b/_posts/2020-11-12-word-generator-freestyle.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title:  "Video: Word Generator Freestyle"
-date:   2020-11-12
-image:  'word-generator-freestyle-2.jpg'
-image_alt:  'Picture of Dylan Hand in front of microphone wearing headphones'
-tags:   raps freestyle word-generator
+title: "Video: Word Generator Freestyle"
+date: 2020-11-12
+image: 'assets/img/word-generator-freestyle-2.jpg'
+image_alt: 'Picture of Dylan Hand in front of microphone wearing headphones'
+tags: raps freestyle word-generator
 ---
 
 Freestyle using [RapScript](https://rapscript.net) to generate words.

--- a/_posts/2021-01-22-word-generator-freestyle.md
+++ b/_posts/2021-01-22-word-generator-freestyle.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title:  "Video: Another Word Generator Freestyle?"
-date:   2021-01-22
-image:  'word-generator-freestyle-3.jpg'
-image_alt:  'Picture of Dylan Hand at micrphone showing phone with word generator app RapScript'
-tags:   raps freestyle word-generator
+title: "Video: Another Word Generator Freestyle?"
+date: 2021-01-22
+image: 'assets/img/word-generator-freestyle-3.jpg'
+image_alt: 'Picture of Dylan Hand at micrphone showing phone with word generator app RapScript'
+tags: raps freestyle word-generator
 ---
 
 These are too fun. Here's another freestyle using [RapScript](https://rapscript.net) to generate words.

--- a/_posts/2021-05-18-presave-fly-high.md
+++ b/_posts/2021-05-18-presave-fly-high.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title:  '"Fly High" coming this Friday'
-date:   2021-05-18
-image:  'fly-high-cover.jpg'
-image_alt:  'Fly High cover art: picture of bird drawn on post-it note in front of the fjords in Noraway'
-tags:   raps single 
+title: '"Fly High" coming this Friday'
+date: 2021-05-18
+image: 'assets/img/fly-high-cover.jpg'
+image_alt: 'Fly High cover art: picture of bird drawn on post-it note in front of the fjords in Noraway'
+tags: raps single 
 ---
 
 The new single, "Fly High," is coming this Friday, May 21. Beat by Ville Petersson. Cover art by yours truly. More details to come Friday.

--- a/_posts/2021-05-21-fly-high.md
+++ b/_posts/2021-05-21-fly-high.md
@@ -2,7 +2,7 @@
 layout: post
 title: 'New Song - "Fly High"'
 date: 2021-05-21
-image: 'fly-high-cover.jpg'
+image: 'assets/img/fly-high-cover.jpg'
 tags: raps single 
 ---
 

--- a/_posts/2021-06-04-letter-to-ashland.md
+++ b/_posts/2021-06-04-letter-to-ashland.md
@@ -2,7 +2,7 @@
 layout: post
 title: 'New Song - "Letter to Ashland"'
 date: 2021-06-04
-image: 'letter-to-ashland-cover.jpg'
+image: 'assets/img/letter-to-ashland-cover.jpg'
 tags: raps single 
 ---
 

--- a/_posts/2021-08-07-freestyle-at-all-my-friends-are-stars-festival.md
+++ b/_posts/2021-08-07-freestyle-at-all-my-friends-are-stars-festival.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title:  "Video: Freestyle at All My Friends Are Stars Festival"
-date:   2021-08-07
-image:  'amfas-freestyle.jpg'
-image_alt:  'Picture of Dylan Hand freestyling at All My Friends Are Stars Festival in Gothenburg'
-tags:   raps freestyle
+title: "Video: Freestyle at All My Friends Are Stars Festival"
+date: 2021-08-07
+image: 'assets/img/amfas-freestyle.jpg'
+image_alt: 'Picture of Dylan Hand freestyling at All My Friends Are Stars Festival in Gothenburg'
+tags: raps freestyle
 ---
 
 Freestyle at [All My Friends Are Stars Music Festival](https://www.allmyfriendsarestars.com/).

--- a/_posts/2021-08-10-bus-stop-bars-freestyle.md
+++ b/_posts/2021-08-10-bus-stop-bars-freestyle.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title:  "Video: Bus Stop Bars Freestyle"
-date:   2021-08-10
-image:  'bus-stop-bars-freestyle.jpg'
-image_alt:  'Picture of Dylan Hand freestyling at a bus stop after festival with crowd in back.'
-tags:   raps freestyle
+title: "Video: Bus Stop Bars Freestyle"
+date: 2021-08-10
+image: 'assets/img/bus-stop-bars-freestyle.jpg'
+image_alt: 'Picture of Dylan Hand freestyling at a bus stop after festival with crowd in back.'
+tags: raps freestyle
 ---
 
 Freestyle after the [festival]({% post_url 2021-08-07-freestyle-at-all-my-friends-are-stars-festival %}).

--- a/_posts/2021-09-10-why-not.md
+++ b/_posts/2021-09-10-why-not.md
@@ -2,7 +2,7 @@
 layout: post
 title: 'New Song - "Why Not"'
 date: 2021-09-10
-image: 'why-not-cover.jpg'
+image: 'assets/img/why-not-cover.jpg'
 tags: raps single 
 ---
 

--- a/_posts/2022-01-04-thanks-for-rocking-with-me-this-year.md
+++ b/_posts/2022-01-04-thanks-for-rocking-with-me-this-year.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-image:  'spotify-wrapped-2021-01.jpg'
-image_alt:  '2021 Spotify Wrapped stats for Dylan Hand'
+image: 'assets/img/spotify-wrapped-2021-01.jpg'
+image_alt: '2021 Spotify Wrapped stats for Dylan Hand'
 tags: spotify-wrapped
 ---
 
-{% picture post spotify-wrapped-2021-02.jpg %}
-{% picture post spotify-wrapped-2021-03.jpg %}
+{% picture post assets/img/spotify-wrapped-2021-02.jpg %}
+{% picture post assets/img/spotify-wrapped-2021-03.jpg %}
 
 Thanks for rocking with me this last year. These numbers are almost entirely from you all sharing these first three songs, which is awesome to me.
 

--- a/_posts/2022-05-20-made-it-there.md
+++ b/_posts/2022-05-20-made-it-there.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'New Song - "Made It There"'
-image: 'made-it-there-cover.jpg'
+image: 'assets/img/made-it-there-cover.jpg'
 tags: raps single 
 ---
 

--- a/_posts/2022-09-23-do-the-kinja.md
+++ b/_posts/2022-09-23-do-the-kinja.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 'New Song - "Do The Kinja"'
-image: 'do-the-kinja-cover.jpg'
+image: 'assets/img/do-the-kinja-cover.jpg'
 tags: raps single 
 ---
 

--- a/_posts/2022-11-30-spotify-wrapped.md
+++ b/_posts/2022-11-30-spotify-wrapped.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-image:  'spotify-wrapped-2022-01.png'
+image: 'assets/img/spotify-wrapped-2022-01.png'
 tags: spotify-wrapped
-image_alt:  '2022 Spotify Wrapped stats for Dylan Hand'
+image_alt: '2022 Spotify Wrapped stats for Dylan Hand'
 title: Another Year Wrapped
 ---
 
-{% picture post spotify-wrapped-2022-02.png %}
-{% picture post spotify-wrapped-2022-03.png %}
+{% picture post assets/img/spotify-wrapped-2022-02.png %}
+{% picture post assets/img/spotify-wrapped-2022-03.png %}
 
 Thanks for rocking with me again this year. 
 

--- a/_posts/2023-09-22-problems.md
+++ b/_posts/2023-09-22-problems.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-image: 'problems-cover.jpg'
+image: 'assets/img/problems-cover.jpg'
 tags: raps single
 title: New Song - "Problems"
 description: What do you do when you have problems?

--- a/_posts/2023-10-13-champagne.md
+++ b/_posts/2023-10-13-champagne.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-image: 'champagne-cover.jpg'
+image: 'assets/img/champagne-cover.jpg'
 tags: raps single
 title: New Song - "Champagne"
 description: Sometimes you gotta talk shit. And enlist the local senior female bocce ball team for a video.

--- a/_posts/2023-11-17-fresh-eyes.md
+++ b/_posts/2023-11-17-fresh-eyes.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-image: 'fresh-eyes-cover.jpg'
+image: 'assets/img/fresh-eyes-cover.jpg'
 tags: raps single
 title: New Song - "Fresh Eyes"
 description: You can feel it in the air right?

--- a/_posts/2023-12-01-spotify-wrapped.md
+++ b/_posts/2023-12-01-spotify-wrapped.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-image:  'spotify-wrapped-2023-01.png'
+image: 'assets/img/spotify-wrapped-2023-01.png'
 tags: spotify-wrapped
 image_alt: '2023 Spotify Wrapped stats for Dylan Hand'
 title: Thanks for a great year
 ---
 
-{% picture post spotify-wrapped-2023-02.png %}
-{% picture post spotify-wrapped-2023-03.png %}
+{% picture post assets/img/spotify-wrapped-2023-02.png %}
+{% picture post assets/img/spotify-wrapped-2023-03.png %}
 
 Thanks for being here. I had a blast this year. The numbers are cool and all but as I say in the vid below, the most rewarding part of this is connecting with y'all.
 

--- a/_posts/2023-12-08-rock-the-boat.md
+++ b/_posts/2023-12-08-rock-the-boat.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-image: 'rock-the-boat-cover.jpg'
+image: 'assets/img/rock-the-boat-cover.jpg'
 tags: raps single
 title: New Song - "Rock The Boat"
 description: An adventurous collab with SUNRAID

--- a/_releases/champagne.md
+++ b/_releases/champagne.md
@@ -5,7 +5,7 @@ permalink: /champagne
 date: 2023-10-13
 title: Champagne by Dylan Hand
 description: fetch me a glass of champagne
-image: champagne-cover.jpg
+image: assets/img/champagne-cover.jpg
 image_alt: 'Champagne cover art: Dylan Hand holding a glass of campagne in his right hand and a bottle of champagne in his left hand wearing a light green button-up linen shirt in a chair in front of a white background'
 artists: Dylan Hand
 bandcamp: https://dylanhand.bandcamp.com/track/champagne

--- a/_releases/do-the-kinja.md
+++ b/_releases/do-the-kinja.md
@@ -5,7 +5,7 @@ permalink: /kinja
 date: 2022-09-23
 title: Do The Kinja by Kindhumans, Dylan Hand & Judith Okon
 description: Be nice.
-image: do-the-kinja-cover.jpg
+image: assets/img/do-the-kinja-cover.jpg
 image_alt: 'Do The Kinja cover art: definition of word kinja, kind ninja'
 artists: [Kindhumans, Dylan Hand, Judith Okon]
 # bandcamp:

--- a/_releases/fly-high.md
+++ b/_releases/fly-high.md
@@ -5,7 +5,7 @@ permalink: /fly-high
 date: 2021-05-21
 title: Fly High by Dylan Hand
 description: Let's get over our bullshit together
-image: 'fly-high-cover.jpg'
+image: 'assets/img/fly-high-cover.jpg'
 image_alt: 'Fly High cover art: picture of bird drawn on post-it note in front of the fjords in Noraway'
 artists: Dylan Hand
 bandcamp: https://dylanhand.bandcamp.com/track/fly-high

--- a/_releases/fresh-eyes.md
+++ b/_releases/fresh-eyes.md
@@ -5,7 +5,7 @@ permalink: /fresh-eyes
 date: 2023-11-17
 title: Fresh Eyes by Dylan Hand
 description: you can feel it in the air right?
-image: fresh-eyes-cover.jpg
+image: assets/img/fresh-eyes-cover.jpg
 image_alt: 'Fresh Eyes cover art: Dylan Hand as a toddler looking up and to the right with his hand outstretched, wearing a pink turtleneck, overalls, orange and yellow beads, and plenty of food on his face.'
 artists: Dylan Hand
 bandcamp: https://dylanhand.bandcamp.com/track/fresh-eyes

--- a/_releases/letter-to-ashland.md
+++ b/_releases/letter-to-ashland.md
@@ -5,7 +5,7 @@ permalink: /letter-to-ashland
 date: 2021-06-04
 title: Letter to Ashland by Dylan Hand
 description: This one's for all my people back home
-image: 'letter-to-ashland-cover.jpg'
+image: 'assets/img/letter-to-ashland-cover.jpg'
 image_alt: 'Letter to Ashland cover art: picture of Oregon drawn on post-it note in front of lush forest'
 artists: Dylan Hand
 bandcamp: https://dylanhand.bandcamp.com/track/letter-to-ashland

--- a/_releases/made-it-there.md
+++ b/_releases/made-it-there.md
@@ -5,7 +5,7 @@ permalink: /made-it-there
 date: 2022-05-20
 title: Made It There by Dylan Hand
 description: i'm with your mom we're sharing a plate of nachos
-image: made-it-there-cover.jpg
+image: assets/img/made-it-there-cover.jpg
 image_alt: 'Made It There cover art: studio photo of Dylan Hand wearing pink alligator shirt and rather blank expression'
 artists: Dylan Hand
 bandcamp: https://dylanhand.bandcamp.com/track/made-it-there

--- a/_releases/problems.md
+++ b/_releases/problems.md
@@ -5,7 +5,7 @@ permalink: /problems
 date: 2023-09-22
 title: Problems by Dylan Hand
 description: i got all these problems
-image: problems-cover.jpg
+image: assets/img/problems-cover.jpg
 image_alt: 'Problems cover art: Dylan Hand holding a fire extinguisher in front of a white background'
 artists: Dylan Hand
 bandcamp: https://dylanhand.bandcamp.com/track/problems

--- a/_releases/rock-the-boat.md
+++ b/_releases/rock-the-boat.md
@@ -5,7 +5,7 @@ permalink: /rock-the-boat
 date: 2023-12-08
 title: Rock The Boat by Dylan Hand produced by SUNRAID
 description: an adventerous collab between Dylan Hand and SUNRAID
-image: rock-the-boat-cover.jpg
+image: assets/img/rock-the-boat-cover.jpg
 image_alt: 'Rock The Boat cover art: Dylan Hand and SUNRAID standing in front of a red boat with a blue background and parental advisory sticker in the top right corner'
 artists: [Dylan Hand, SUNRAID]
 bandcamp: https://dylanhand.bandcamp.com/track/rock-the-boat

--- a/_releases/sole.md
+++ b/_releases/sole.md
@@ -5,7 +5,7 @@ permalink: /sole
 date: 2020-08-17
 title: Sole by Rotaris & Dylan Hand
 description: Dedicated to all you sickos out there
-image: 'sole.jpg'
+image: 'assets/img/sole.jpg'
 image_alt: 'Sole cover art: a picture of a tissue box'
 artists: 
     - Rotaris

--- a/_releases/why-not.md
+++ b/_releases/why-not.md
@@ -5,7 +5,7 @@ permalink: /why-not
 date: 2021-09-10
 title: Why Not by Dylan Hand
 description: hope u like lots of beat switches and crazy rap
-image: 'why-not-cover.jpg'
+image: 'assets/img/why-not-cover.jpg'
 image_alt: 'Why Not cover art: unsophisticated digital drawing of goat in front of flaming background'
 artists: Dylan Hand
 bandcamp: https://dylanhand.bandcamp.com/track/why-not


### PR DESCRIPTION
Temporary fix for broken link previews when posting to sites like X/Twitter or sending via iMessage.

Uses unoptimized images which load slowly, but at least they work.

Evidently `jekyll-seo-tag` and `jekyll-picture-tag` don't play nice. They both want to use the `image` frontmatter property, but since JPT generates new images during build, it's too late to tell JST about them.